### PR TITLE
Fix decoding in API route params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Install dependencies
         run: rustup component add rustfmt clippy
 
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path api/Cargo.toml
+
       - name: Run rustfmt
         uses: actions-rs/cargo@v1
         with:

--- a/api/src/util/mod.rs
+++ b/api/src/util/mod.rs
@@ -138,7 +138,7 @@ impl<'r> FromParam<'r> for SpotifyUri {
     type Error = ApiError;
 
     fn from_param(param: &'r RawStr) -> Result<Self, Self::Error> {
-        param.as_str().parse()
+        param.percent_decode()?.parse()
     }
 }
 


### PR DESCRIPTION
`SpotifyUri` URL params weren't being decoded. A recent UI change meant the `/api/items/<uri>` endpoint didn't work properly.